### PR TITLE
Snipe task: Keeping 'missing' Pokemon + sorting order correction

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -277,8 +277,11 @@ class Sniper(BaseTask):
                 if pokemon.get('vip', False):
                     self._trace('{} is not catchable and bad IV (if any), however its a VIP!'.format(pokemon.get('pokemon_name')))
                 else:
-                    self._trace('{} is not catachable, nor a VIP and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
-                    return False
+                    if pokemon['missing']:
+                        self._trace('{} is not catchable, not VIP and bad IV (if any), however its a missing one.'.format(pokemon.get('pokemon_name')))
+                    else:
+                        self._trace('{} is not catachable, nor a VIP or a missing one and bad IV (if any). Skipping...'.format(pokemon.get('pokemon_name')))
+                        return False
 
         return True
 
@@ -362,8 +365,7 @@ class Sniper(BaseTask):
 
             if targets:
                 # Order the targets (descending)
-                for attr in self.order:
-                    targets.sort(key=lambda pokemon: pokemon[attr], reverse=True)
+                targets = sorted(targets, key=itemgetter(*self.order), reverse=True)
 
                 shots = 0
 


### PR DESCRIPTION
- A 'missing' only Pokemon (not on the catch_list, no VIP and with a bad
IV) will now be keep on the list as a potential target if 'missing' is
specified on the order option

- The sorting of the targer list is modified to be cumulative.
For example, if the `order` option is [`missing`, `vip`, `priority`],
then the list will be ordered by 'missing' first, and then VIP's, and
finally by Priority.