### PR TITLE
Sniper task : Correction of expired Pokemon Calculation

### DIFF
--- a/pokemongo_bot/cell_workers/sniper.py
+++ b/pokemongo_bot/cell_workers/sniper.py
@@ -69,7 +69,6 @@ class SniperSource(object):
                         local_date = datetime.fromtimestamp(unix_timestamp)
                         local_date = local_date.replace(microsecond=utc_date.microsecond)
                         expiration = time.mktime(local_date.timetuple()) * 1000
-                else:
                     minutes_to_expire = 3
                     seconds_per_minute = 60
                     expiration = (time.time() + minutes_to_expire * seconds_per_minute) * 1000


### PR DESCRIPTION
Currently, if the source contain an _expiration_ data, **every** Pokemon
are wrongly tagged as expired.